### PR TITLE
Use cmake metabuild system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.teto
 *.btree
 *.txt
+!CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(TetoDB)
+
+set(CMAKE_CXX_STANDARD 23)
+
+file(GLOB CPP_SOURCES "*.cpp")
+
+add_executable(TetoDB ${CPP_SOURCES})

--- a/Pager.cpp
+++ b/Pager.cpp
@@ -14,6 +14,8 @@
     // Windows permissions
     #define S_IWUSR S_IWRITE
     #define S_IRUSR S_IREAD
+    #include <cstddef>
+    using ssize_t = ptrdiff_t;
 #else
     #include <unistd.h> // Linux/Mac standard
 #endif


### PR DESCRIPTION
- Using cmake to generate build file
- Include <cstddef> for ssize_t since this is POSIX standard type, not C++ standard type, so that it can be built on windows